### PR TITLE
Added optional params argument to assetDividendRecord

### DIFF
--- a/node-binance-api.js
+++ b/node-binance-api.js
@@ -3112,8 +3112,8 @@ let api = function Binance( options = {} ) {
           signedRequest(sapi + 'v1/asset/dust', { asset: assets }, callback, 'POST');
         },
 
-        assetDividendRecord: function (callback) {
-          signedRequest(sapi + 'v1/asset/assetDividend', {}, callback);
+        assetDividendRecord: function (callback, params = {}) {
+          signedRequest(sapi + 'v1/asset/assetDividend', params, callback);
         },
 
         /**


### PR DESCRIPTION
Params (limit, start and end time) are needed to support pagination for asset dividend records. They remain optional.